### PR TITLE
Changed "licenses" to "license"

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "vue-component",
     "vue-slider-component"
   ],
-  "licenses": "MIT",
+  "license": "MIT",
   "lint-staged": {
     "*.{js,ts,tsx,scss}": [
       "npm run prettier",


### PR DESCRIPTION
According to https://docs.npmjs.com/files/package.json, correct one is license and not licenses, because of that some licence/license validation tools might fail as they look for "license".